### PR TITLE
Updated version for REST API versioning change

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,6 +1,6 @@
 namespace: brocade
 name: fos
-version: 1.3.0
+version: 1.3.1
 readme: README.md
 authors:
   - Brocade Automation Team <Automation.BSN@broadcom.com>

--- a/test_version_matrix.rst
+++ b/test_version_matrix.rst
@@ -10,3 +10,6 @@ notes section provide the details on the exceptions and release notes.
 |     1.3.0     |    8.2.3a   |  The minimum FOS version for module      |
 |               |             |  firmwaredownload is v9.0.0.             |
 +---------------+-------------+------------------------------------------+
+|     1.3.1     |    9.1.x    |                                          |
+|               |             |                                          |
++---------------+-------------+------------------------------------------+


### PR DESCRIPTION
Updated REST API version to 1.3.1, since there are no new modules added to this changes.