### PR TITLE
Fix for unwanted cfgenable.

### DIFF
--- a/utils/brocade_zoning.py
+++ b/utils/brocade_zoning.py
@@ -741,17 +741,11 @@ def zoning_common(fos_ip_addr, https, fos_version, auth, vfid, result, module, i
         if active_cfg is None:
             if need_to_save:
                 if not module.check_mode:
-                    # if something changed and there is already an active cfg
-                    # reenable that cfg
+                    # Just save config when there is no active_cfg value.
+                    # According to documentation of module brocade_zoning_cfg.
                     ret_code = 0
-                    failed_msg = ""
-                    if cfgname is not None:
-                        failed_msg = "CFG ENABLE failed"
-                        ret_code = cfg_enable(fos_ip_addr, https, fos_version, auth, vfid,
-                                            result, checksum, cfgname, timeout)
-                    else:
-                        failed_msg = "CFG SAVE failed"
-                        ret_code = cfg_save(fos_ip_addr, https, fos_version, auth, vfid,
+                    failed_msg = "CFG SAVE failed"
+                    ret_code = cfg_save(fos_ip_addr, https, fos_version, auth, vfid,
                                         result, checksum, timeout)
                     if ret_code != 0:
                         ret_code = cfg_abort(fos_ip_addr, https, fos_version,
@@ -802,15 +796,11 @@ def zoning_common(fos_ip_addr, https, fos_version, auth, vfid, result, module, i
         if active_cfg is None:
             if need_to_save:
                 if not module.check_mode:
+                    # Just save config when there is no active_cfg value.
+                    # According to documentation of module brocade_zoning_cfg.
                     ret_code = 0
-                    failed_msg = ""
-                    if cfgname is not None:
-                        failed_msg = "CFG ENABLE failed"
-                        ret_code = cfg_enable(fos_ip_addr, https, fos_version, auth, vfid,
-                                            result, checksum, cfgname, timeout)
-                    else:
-                        failed_msg = "CFG SAVE failed"
-                        ret_code = cfg_save(fos_ip_addr, https, fos_version, auth, vfid,
+                    failed_msg = "CFG SAVE failed"
+                    ret_code = cfg_save(fos_ip_addr, https, fos_version, auth, vfid,
                                         result, checksum, timeout)
                     if ret_code != 0:
                         ret_code = cfg_abort(fos_ip_addr, https, fos_version, auth,


### PR DESCRIPTION
According to documentation there should be no cfg_enable when active_cfg is empty.

This issue is described in #138.

I think the code can be improved further especially in the `else` part of `if active_cfg is None:`. I think we need an additional cfgsave here - to be tested.