### PR TITLE
FOSANS-128: HTTPS certificate import using playbook fails

### DIFF
--- a/utils/brocade_objects.py
+++ b/utils/brocade_objects.py
@@ -36,7 +36,7 @@ REST_PREFIX = "/rest/running/"
 OP_PREFIX = "/rest/operations/"
 
 BASE64_PWD_ERROR = "Password can not be decoded"
-
+WEBL_REBOOT_TIME = 30
 
 def get_moduleName(fos_version, module_name):
     result = ""
@@ -952,6 +952,11 @@ def singleton_helper(module, fos_ip_addr, fos_user_name, fos_password, https,
     except Exception as e:
         logout(fos_ip_addr, https, auth, result, timeout)
         raise
+
+    if (module_name == "brocade_security" and obj_name == "security_certificate_action" and
+        len(diff_attributes) > 0 and diff_attributes["certificate-type"] == "https" and
+        diff_attributes["operation"] == "import"):
+        time.sleep(WEBL_REBOOT_TIME)
 
     logout(fos_ip_addr, https, auth, result, timeout)
     module.exit_json(**result)


### PR DESCRIPTION
 This issue is there from day one for the https certificates. 
      Ansible playbook will login to switch, execute the playbook, and logout from the switch.
      But in this playbook case, login went fine. But during the execution of the playbook, we are importing the https certificates to the switch,
      which will restart the Apache webserver on the switch.
      Since the Apache web server is restarted, logout fails with "Chassis not ready for management".

      Solution in this case is as follows:
           1. Skip logout for the HTTPS certificate import case
               Disadvantage: Sessions are left out on the switch
           2. Delay logout for the HTTPS certificate import case
                Advantage: Sessions gets cleaned up
                Disadvantage: More time to complete the playbook which is anyway needed to make this case work

      Since solution 2 is appropriate for this went with it.